### PR TITLE
Freeze dry-configurable version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [0.1.1] - 2017-08-25
+### Fixed
+
+- Freeze `dry-configurable` version

--- a/keepit.gemspec
+++ b/keepit.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "redis"
-  spec.add_runtime_dependency "dry-configurable"
+  spec.add_runtime_dependency "dry-configurable", '>= 0.7.0'
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/keepit/version.rb
+++ b/lib/keepit/version.rb
@@ -1,3 +1,3 @@
 module Keepit
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end


### PR DESCRIPTION
опция`reader` была добавлена в 0.7.0
в версиях ниже валится с ошибкой
```
wrong number of arguments (3 for 1..2)
/bundle/2.2/gems/dry-configurable-0.5.0/lib/dry/configurable.rb:83:in `setting'
```